### PR TITLE
Fixed: memory overrun in examples

### DIFF
--- a/GoBLE_APP/GoBLE_APP.ino
+++ b/GoBLE_APP/GoBLE_APP.ino
@@ -23,7 +23,7 @@ int RightWheelSpeed;
 //GoBle configuration library, help user to identify control button and stick on Gamepad
 #include "GoBLE.h"
 int joystickX, joystickY;
-int buttonState[6];
+int buttonState[MAXBUTTONID];
 
 int ledPin = 13;
 
@@ -41,7 +41,7 @@ void loop (){
 //    Serial.print("joystickX: ");
 //    Serial.print(joystickX);
 //    Serial.print("joystickY: ");
-//    Serial.println(joystickX);
+//    Serial.println(joystickY);
 
     buttonState[SWITCH_UP]     = Goble.readSwitchUp();
     buttonState[SWITCH_LEFT]   = Goble.readSwitchLeft();

--- a/GoBLE_Test/GoBLE_Test.ino
+++ b/GoBLE_Test/GoBLE_Test.ino
@@ -2,7 +2,7 @@
 #include "GoBLE.h"
 
 int joystickX, joystickY;
-int buttonState[6];
+int buttonState[MAXBUTTONID];
 
 void setup(){
   Goble.begin();


### PR DESCRIPTION
Examples are not working properly in the Arduino IDE 1.6.9 due to incorrect array size
